### PR TITLE
Added a section on setting up shifts on a local machine for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ Shallow routing is used but bear in mind form_for must be treated differently fo
 * `/loc_groups/:loc_group_id/*`
 	* (`require_loc_groug_admin`)
 
+## 5. Setting Up for Development
+
+See the wiki page [here](https://github.com/YaleSTC/shifts/wiki) for instructions on setting up a local Linux machine for development. 
 
 ## CREDITS
 


### PR DESCRIPTION
Link to issue: https://github.com/YaleSTC/shifts/issues/218

I added a section to README.md that links to the installation instructions in the YaleSTC wiki. I pushed the change up to Github on this branch and tested the link; it works fine. 

This change hopefully will make it clearer where the setup instructions are for newDevs!
