### PR TITLE
Switched default layout of StatsController to `shifts`

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,5 +1,5 @@
 class StatsController < ApplicationController
-  layout 'stats'
+  layout 'shifts'
 
   def index
     @start_date = interpret_start


### PR DESCRIPTION
After @mnquintana's great 2014 purge of layouts, StatsController was left loading a non-existent layout. We switched it to an equivalent existent one. Yay!
