### PR TITLE
Change placeholder text for Mac users

### DIFF
--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,3 +1,10 @@
 module ReportsHelper
+  def report_kbd_shortcut
+    if request.env['HTTP_USER_AGENT'].downcase.match(/mac/i)
+      'Cmd+Enter to quickly add to report!'
+    else
+      'Ctrl+Enter to quickly add to report!'
+    end
+  end
 end
 

--- a/app/views/reports/_new_report_item_form.html.erb
+++ b/app/views/reports/_new_report_item_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for [@report, @report_item], remote: true, id: 'report_item_form' do |f| %>
   <%= f.error_messages %>
   <% if request.env['HTTP_USER_AGENT'].downcase.match(/mac/i) %>
-    <%= f.text_area :content, placeholder: 'Command+Enter to quickly add to report!', id: 'item', size: '40x3', wrap: 'hard', class: 'form-control' %>
+    <%= f.text_area :content, placeholder: 'Cmd+Enter to quickly add to report!', id: 'item', size: '40x3', wrap: 'hard', class: 'form-control' %>
   <% else %>
     <%= f.text_area :content, placeholder: 'Ctrl+Enter to quickly add to report!', id: 'item', size: '40x3', wrap: 'hard', class: 'form-control' %>
   <% end %>

--- a/app/views/reports/_new_report_item_form.html.erb
+++ b/app/views/reports/_new_report_item_form.html.erb
@@ -1,11 +1,7 @@
 <%= form_for [@report, @report_item], remote: true, id: 'report_item_form' do |f| %>
   <%= f.error_messages %>
-  <% if request.env['HTTP_USER_AGENT'].downcase.match(/mac/i) %>
-    <%= f.text_area :content, placeholder: 'Cmd+Enter to quickly add to report!', id: 'item', size: '40x3', wrap: 'hard', class: 'form-control' %>
-  <% else %>
-    <%= f.text_area :content, placeholder: 'Ctrl+Enter to quickly add to report!', id: 'item', size: '40x3', wrap: 'hard', class: 'form-control' %>
-  <% end %>
-  <%= f.submit "Add to report", id: 'report_item_submit', title: 'Ctrl+Enter to add to shift report', class: 'btn btn-primary', data: { disable_with: "Submitting..." } %>
+  <%= f.text_area :content, placeholder: report_kbd_shortcut, id: 'item', size: '40x3', wrap: 'hard', class: 'form-control' %>
+  <%= f.submit "Add to report", id: 'report_item_submit', title: report_kbd_shortcut, class: 'btn btn-primary', data: { disable_with: "Submitting..." } %>
   <div id="submit_button">
     <%= params[:popup] %>
   </div>

--- a/app/views/reports/_new_report_item_form.html.erb
+++ b/app/views/reports/_new_report_item_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_for [@report, @report_item], remote: true, id: 'report_item_form' do |f| %>
   <%= f.error_messages %>
-  <%= f.text_area :content, placeholder: 'Ctrl+Enter to quickly add to report!', id: 'item', size: '40x3', wrap: 'hard', class: 'form-control' %>
+  <% if request.env['HTTP_USER_AGENT'].downcase.match(/mac/i) %>
+    <%= f.text_area :content, placeholder: 'Command+Enter to quickly add to report!', id: 'item', size: '40x3', wrap: 'hard', class: 'form-control' %>
+  <% else %>
+    <%= f.text_area :content, placeholder: 'Ctrl+Enter to quickly add to report!', id: 'item', size: '40x3', wrap: 'hard', class: 'form-control' %>
+  <% end %>
   <%= f.submit "Add to report", id: 'report_item_submit', title: 'Ctrl+Enter to add to shift report', class: 'btn btn-primary', data: { disable_with: "Submitting..." } %>
   <div id="submit_button">
     <%= params[:popup] %>


### PR DESCRIPTION
This is based on the HTTP_USER_AGENT field to detect the OS.
The button title below isn't changed but that isn't readily available to the user.
Tested by toggling the if statement to `if !request.env...`

See #434.